### PR TITLE
Handle OSM API JSON Response

### DIFF
--- a/main.js
+++ b/main.js
@@ -188,8 +188,7 @@ const getProfileImageUrl = (userId) => {
         log(`Using cached profile image for ${userId}`);
         return cached;
     } else {
-        const get = axios.get(`https://api.openstreetmap.org/api/0.6/user/${userId}`).then(response => {
-            // TODO handle if it goes back to XML?
+        const get = axios.get(`https://api.openstreetmap.org/api/0.6/user/${userId}.json`).then(response => {
             const url = response.data.user.img ? response.data.user.img.href : null;
             log(`Cached profile image for ${userId} as ${url}`);
             return url;

--- a/main.js
+++ b/main.js
@@ -189,12 +189,10 @@ const getProfileImageUrl = (userId) => {
         return cached;
     } else {
         const get = axios.get(`https://api.openstreetmap.org/api/0.6/user/${userId}`).then(response => {
-            return parseXML(response.data)
-                .then(xml => xml.osm.user[0].img ? xml.osm.user[0].img[0].$.href : null)
-                .then(url => {
-                    log(`Cached profile image for ${userId} as ${url}`);
-                    return url;
-                });
+            // TODO handle if it goes back to XML?
+            const url = response.data.user.img ? response.data.user.img.href : null;
+            log(`Cached profile image for ${userId} as ${url}`);
+            return url;
         });
         profileImageUrlCache[userId] = get;
         return get;


### PR DESCRIPTION
Bot failed at ~2pm AEST on 1/10/2020.
Diagnosis is that the OSM api started honouring the `Accept: application/json` header, and responded with JSON.

![image](https://user-images.githubusercontent.com/13784116/94889867-fd9ba500-04c0-11eb-8b7d-b2fb4ec8b3ed.png)

### Fix
Remove XML parsing, and explicitly request JSON format with `.json` at end of URL.
